### PR TITLE
Update use-compute.ts

### DIFF
--- a/packages/fast-crud/src/use/use-compute.ts
+++ b/packages/fast-crud/src/use/use-compute.ts
@@ -35,7 +35,12 @@ function findComputeValues(target, excludes, isAsync) {
       return false;
     }
     return true;
-  });
+  },
+    {
+        // https://deepdash.io/#eachdeep-foreachdeep
+        checkCircular: true
+    }
+  );
 
   return foundMap;
 }


### PR DESCRIPTION
更新了vue 3.2.27以后似乎会死循环引用，在ref里面嵌套computed的时候，得加上checkCircular: true 才行

[复现demo](https://github.com/aov2005/fast-crud-vue3.27)