### PR TITLE
fix 解决找不到@type/jest的问题 兼容fs的page请求类型

### DIFF
--- a/packages/fast-crud/package.json
+++ b/packages/fast-crud/package.json
@@ -29,7 +29,7 @@
     "@rollup/plugin-strip": "^2.0.0",
     "@rollup/plugin-typescript": "^8.3.3",
     "@types/chai": "^4.3.3",
-    "@types/jest": "^29.1.1",
+    "@types/jest": "^29.4.0",
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.8.0",
     "@typescript-eslint/eslint-plugin": "^5.38.1",

--- a/packages/fast-crud/src/d.ts/crud.ts
+++ b/packages/fast-crud/src/d.ts/crud.ts
@@ -91,7 +91,7 @@ export type UserPageQuery = {
 
 export type TransformQuery = (query: PageQuery) => UserPageQuery;
 export type TransformRes = (userPageRes: UserPageRes) => PageRes;
-export type PageRequest = (query: UserPageQuery) => Promise<UserPageRes>;
+export type PageRequest = (query: UserPageQuery | PageQuery) => Promise<UserPageRes | PageRes>;
 export type EditRequest = (req: EditReq) => Promise<any>;
 export type AddRequest = (req: AddReq) => Promise<any>;
 export type DelRequest = (req: DelReq) => Promise<any>;


### PR DESCRIPTION
重新装一下依赖就可以解决找不到@type/jest的问题

现在按照fs定义的pageQuery和pageRes写的接口反而会提示错误，需要修改PageRequest的类型