### PR TITLE
修复上传控件配置问题

### DIFF
--- a/packages/fast-extends/src/uploader/components/fs-uploader-alioss.vue
+++ b/packages/fast-extends/src/uploader/components/fs-uploader-alioss.vue
@@ -35,7 +35,7 @@ async function getSts(config) {
 async function doUpload({ file, fileName, onProgress, options }) {
   const key = await buildKey(file, fileName, options);
   let sts = null;
-  if (options.accessKeyId && options.accessKeySecret && options.getAuthorization !== null) {
+  if (!options.accessKeyId && !options.accessKeySecret && options.getAuthorization !== null) {
     sts = await getSts({
       key,
       file,

--- a/packages/fast-extends/src/uploader/components/fs-uploader-alioss.vue
+++ b/packages/fast-extends/src/uploader/components/fs-uploader-alioss.vue
@@ -35,7 +35,7 @@ async function getSts(config) {
 async function doUpload({ file, fileName, onProgress, options }) {
   const key = await buildKey(file, fileName, options);
   let sts = null;
-  if (options.getAuthorization !== null) {
+  if (options.accessKeyId && options.accessKeySecret && options.getAuthorization !== null) {
     sts = await getSts({
       key,
       file,

--- a/packages/fast-extends/src/uploader/components/fs-uploader-cos.vue
+++ b/packages/fast-extends/src/uploader/components/fs-uploader-cos.vue
@@ -12,7 +12,7 @@ function newClient(options) {
   const secretId = options.secretId;
   const secretKey = options.secretKey;
   const getAuthorization = options.getAuthorization;
-  if (secretId && secretKey && getAuthorization) {
+  if (!secretId && !secretKey && getAuthorization) {
     client = new COS({
       // 必选参数
       getAuthorization(options, callback) {

--- a/packages/fast-extends/src/uploader/components/fs-uploader-cos.vue
+++ b/packages/fast-extends/src/uploader/components/fs-uploader-cos.vue
@@ -12,7 +12,7 @@ function newClient(options) {
   const secretId = options.secretId;
   const secretKey = options.secretKey;
   const getAuthorization = options.getAuthorization;
-  if (getAuthorization) {
+  if (secretId && secretKey && getAuthorization) {
     client = new COS({
       // 必选参数
       getAuthorization(options, callback) {


### PR DESCRIPTION
上传控件的默认配置会与用户的配置合并。而默认配置里有getAuthorization方法。导致上传控件无法使用AccessId & AccessKey方式上传。

默认配置位置：
`/packages/fast-extends/src/uploader/type/config.js`