### PR TITLE
Update fs-cropper-uploader.vue

### DIFF
--- a/packages/fast-extends/src/uploader/components/fs-cropper-uploader.vue
+++ b/packages/fast-extends/src/uploader/components/fs-cropper-uploader.vue
@@ -157,6 +157,8 @@ export default defineComponent({
       }
       if (typeof value === "string") {
         list.push({ url: await props.buildUrl(value), value: value, status: "done" });
+      } else if (typeof value === "object") {
+        list.push({ url: await props.buildUrl(value), value, status: "done" });
       } else {
         for (const item of value) {
           list.push({ url: await props.buildUrl(item), value: item, status: "done" });


### PR DESCRIPTION
fix: 设置valueType: 'object'属性后，编辑页面回显头像时，
1. 若给头像赋值为object，initValue方法会报错。