### PR TITLE
feat: 通过removeBinding传递原生属性

### DIFF
--- a/packages/fast-crud/src/use/use-expose.ts
+++ b/packages/fast-crud/src/use/use-expose.ts
@@ -653,7 +653,8 @@ export function useExpose<R = any>(props: UseExposeProps<R>): UseExposeRet<R> {
           await ui.messageBox.confirm({
             title: removeBinding.confirmTitle || t("fs.rowHandle.remove.confirmTitle"), // '提示',
             message: removeBinding.confirmMessage || t("fs.rowHandle.remove.confirmMessage"), // '确定要删除此记录吗?',
-            type: "warn"
+            type: "warn",
+            ...removeBinding
           });
         }
       } catch (e) {


### PR DESCRIPTION
解决： https://github.com/fast-crud/fast-crud/issues/382 中的删除弹框对原生属性的支持