### PR TITLE
字典的数据获取返回类型保证是数组否则导致fs-dict-select遍历computedOptions报错

### DIFF
--- a/packages/fast-crud/src/use/use-dict-define.ts
+++ b/packages/fast-crud/src/use/use-dict-define.ts
@@ -343,11 +343,21 @@ export class Dict<T = any> extends UnMergeable implements DictOptions<T> {
     if (this.getData != null) {
       getFromRemote = async () => {
         // @ts-ignore
-        return await this.getData({ url, dict: this, ...context });
+        const maybeArr = await this.getData({ url, dict: this, ...context });
+        if (Array.isArray(maybeArr)) {
+          return maybeArr;
+        } else {
+          return [];
+        }
       };
     } else if (url) {
       getFromRemote = async () => {
-        return await dictRequest({ url, dict: this });
+        const maybeArr = await dictRequest({ url, dict: this });
+        if (Array.isArray(maybeArr)) {
+          return maybeArr;
+        } else {
+          return [];
+        }
       };
     } else {
       return [];


### PR DESCRIPTION

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/350e2411-4f46-485f-9329-fd8b1fc01d9b">

在dict类中getRemoteDictData函数返回值中，不能保证用户完全按照预期返回数组格式的数据（比如有的项目需求是请求异常了也好返回一个{code:1,msg:'异常'}对象时），这样会导致dict实例的_data为非数组格式，进而导致dict类型的组件报错比如在`fs-dict-select.tsx`组件遍历`computedOptions`时抛出异常。
<img width="828" alt="image" src="https://github.com/user-attachments/assets/54180370-b62d-4cfb-9cc4-f11351628194">
